### PR TITLE
Add __divdf3, __divsf3, __muldf3 and __mulsf3 to blacklist

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,8 @@ fn main() {
         cx.blacklist.insert("__divsi3");
         cx.blacklist.insert("__divdi3");
         cx.blacklist.insert("__divti3");
+        cx.blacklist.insert("__divdf3");
+        cx.blacklist.insert("__divsf3");
         cx.blacklist.insert("__modsi3");
         cx.blacklist.insert("__moddi3");
         cx.blacklist.insert("__modti3");
@@ -82,6 +84,8 @@ fn main() {
         cx.blacklist.insert("__divmoddi4");
         cx.blacklist.insert("__muldi3");
         cx.blacklist.insert("__multi3");
+        cx.blacklist.insert("__muldf3");
+        cx.blacklist.insert("__mulsf3");
         cx.blacklist.insert("__mulosi4");
         cx.blacklist.insert("__mulodi4");
         cx.blacklist.insert("__muloti4");


### PR DESCRIPTION
These four functions were exported, but don't seem necessary, removing them cut 3kB from my module.

Note: I don't know anything about webassembly, so I hope I didn't break anything!