### PR TITLE
Update README.md - add WSL instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,11 @@ at your option.
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in this project by you, as defined in the Apache-2.0 license,
   shall be dual licensed as above, without any additional terms or conditions.
+
+### WSL (Windows Subsystem for Linux)
+
+Install `gcc`:
+
+`sudo apt install gcc -y`
+
+and then install the crate: `cargo install --git https://github.com/alexcrichton/wasm-gc`

--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@ for inclusion in this project by you, as defined in the Apache-2.0 license,
 
 Install `gcc`:
 
-`sudo apt install gcc -y`
+`sudo apt update && sudo apt install gcc -y`
 
 and then install the crate: `cargo install --git https://github.com/alexcrichton/wasm-gc`


### PR DESCRIPTION
References https://github.com/alexcrichton/wasm-gc/issues/5

### Still has an error 😭 

error: could not exec the linker `cc`: No such file or directory (os error 2)
  |
  = note: "cc" "-Wl,--as-needed" "-Wl,-z,noexecstack" "-m64" "-L" "/home/selfup/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib" "/tmp/cargo-install.YjjakbLYNBgO/release/deps/wasm_gc-220fb6710333d060.wasm_gc0.rcgu.o" "-o" "/tmp/cargo-install.YjjakbLYNBgO/release/deps/wasm_gc-220fb6710333d060" "/tmp/cargo-install.YjjakbLYNBgO/release/deps/wasm_gc-220fb6710333d060.crate.allocator.rcgu.o" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-Wl,-O1" "-nodefaultlibs" "-L" "/tmp/cargo-install.YjjakbLYNBgO/release/deps" "-L" "/home/selfup/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-Wl,-Bstatic" "/tmp/cargo-install.YjjakbLYNBgO/release/deps/libenv_logger-00e3003c8ba14f89.rlib" "/tmp/cargo-install.YjjakbLYNBgO/release/deps/libparity_wasm-353ddb98eb2b0520.rlib" "/tmp/cargo-install.YjjakbLYNBgO/release/deps/libbyteorder-3088e227f96eed4c.rlib" "/tmp/cargo-install.YjjakbLYNBgO/release/deps/liblog-b8bca32e3b1fbf3b.rlib" "/tmp/cargo-install.YjjakbLYNBgO/release/deps/libparking_lot-983789a352d7dd79.rlib" "/tmp/cargo-install.YjjakbLYNBgO/release/deps/libowning_ref-b0ac86dab5cfa5b4.rlib" "/tmp/cargo-install.YjjakbLYNBgO/release/deps/libstable_deref_trait-33a4ea7853d971e7.rlib" "/tmp/cargo-install.YjjakbLYNBgO/release/deps/libparking_lot_core-9f87afe6dffcdf4e.rlib" "/tmp/cargo-install.YjjakbLYNBgO/release/deps/librand-4448adbdcf79d3b7.rlib" "/tmp/cargo-install.YjjakbLYNBgO/release/deps/libsmallvec-41895afb1a75c272.rlib" "/tmp/cargo-install.YjjakbLYNBgO/release/deps/liblibc-a12f8fa54a53769e.rlib" "/home/selfup/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd-cc8b303e3403a89b.rlib" "/home/selfup/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libpanic_unwind-7ea6f64ea02051fd.rlib" "/home/selfup/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/liballoc_jemalloc-f1fba9b54042d271.rlib" "/home/selfup/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libunwind-46a427bcbb71fa34.rlib" "/home/selfup/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/liballoc_system-afe41ccc67b2a14a.rlib" "/home/selfup/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/liblibc-aac5870ffe4fa74c.rlib" "/home/selfup/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/liballoc-6a8e7eff29b6cad2.rlib" "/home/selfup/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd_unicode-a768e53a3f571290.rlib" "/home/selfup/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcore-016e6e96bb6127b9.rlib" "/home/selfup/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcompiler_builtins-f2b084cc7a7d8bb1.rlib" "-Wl,-Bdynamic" "-l" "util" "-l" "util" "-l" "dl" "-l" "rt" "-l" "pthread" "-l" "pthread" "-l" "gcc_s" "-l" "c" "-l" "m" "-l" "rt" "-l" "pthread" "-l" "util" "-l" "util"

error: aborting due to previous error

error: failed to compile `wasm-gc v0.1.0 (https://github.com/alexcrichton/wasm-gc#6fe4e9de)`, intermediate artifacts can be found at `/tmp/cargo-install.YjjakbLYNBgO`

Caused by:
  Could not compile `wasm-gc`.

To learn more, run the command again with --verbose.