### PR TITLE
Demangle symbols while processing the name section

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,12 +1,3 @@
-[root]
-name = "wasm-gc"
-version = "0.1.0"
-dependencies = [
- "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-wasm 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "bitflags"
 version = "0.7.0"
@@ -109,6 +100,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "smallvec"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,6 +113,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "stable_deref_trait"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "wasm-gc"
+version = "0.1.0"
+dependencies = [
+ "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-wasm 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "winapi"
@@ -142,6 +148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "149d8f5b97f3c1133e3cfcd8886449959e856b557ff281e292b733d7c69e005e"
 "checksum parking_lot_core 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "4f610cb9664da38e417ea3225f23051f589851999535290e077939838ab7a595"
 "checksum rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "61efcbcd9fa8d8fbb07c84e34a8af18a1ff177b449689ad38a6e9457ecc7b2ae"
+"checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
 "checksum smallvec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ee4f357e8cd37bf8822e1b964e96fd39e2cb5a0424f8aaa284ccaccc2162411c"
 "checksum stable_deref_trait 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "15132e0e364248108c5e2c02e3ab539be8d6f5d52a01ca9bbf27ed657316f02b"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 parity-wasm = "0.15"
 log = "0.3"
 env_logger = { version = "0.4", default-features = false }
+rustc-demangle = "0.1.5"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ extern crate parity_wasm;
 #[macro_use]
 extern crate log;
 extern crate env_logger;
+extern crate rustc_demangle;
 
 use std::collections::{BTreeSet, HashSet};
 use std::env;
@@ -713,6 +714,7 @@ impl<'a> RemapContext<'a> {
     fn serialize_name_map(&self, names: &[(u32, &str)], dst: &mut Vec<u8>) {
         VarUint32::from(names.len()).serialize(dst).unwrap();
         for &(index, name) in names {
+            let name = format!("{}", rustc_demangle::demangle(name));
             VarUint32::from(index).serialize(dst).unwrap();
             VarUint32::from(name.len()).serialize(dst).unwrap();
             dst.extend(name.as_bytes());


### PR DESCRIPTION
From the wasm spec ([name section] and [name encoding]) symbol names are encoded in utf8 so they do not need to be mangled in the final artifact.  In addition to being easier to read, the demangled symbols save a few additional bytes in the output.

Per the spec the assigned names do not need to be unique, however as the default option the hash at the end of the symbol is left intact.  A command line argument could be added to customize this behavior in the future.

The primary reason for leaving the hash is that we are not certain the tool ecosystem will handle this in a consistent way.  For instance, it would be confusing if `wat2wasm` adds a `.3` suffix to the 4th copy of a function (0 indexed) while another tool adds `.4` resulting in potential confusion.

[name section]: https://webassembly.github.io/spec/appendix/custom.html#name-section
[name encoding]: https://webassembly.github.io/spec/binary/values.html#names

cc @alexcrichton @shepmaster